### PR TITLE
Make `bazel build --build_tests_only ...` pass.

### DIFF
--- a/hrepl/RuleInfo/BUILD.bazel
+++ b/hrepl/RuleInfo/BUILD.bazel
@@ -19,6 +19,7 @@ haskell_test(
     srcs = ["ExecutionRootTest.hs"],
     deps = [
         ":execution_root",
+        "@stackage//:base",
         "@stackage//:HUnit",
         "@stackage//:test-framework-hunit",
         "@stackage//:test-framework",

--- a/hrepl/tests/test.bzl
+++ b/hrepl/tests/test.bzl
@@ -75,6 +75,6 @@ def hrepl_test(name="", test_args=[], commands=[], expected_output="", tags=[], 
         test_args = test_args,
         commands = commands,
         expected_output = expected_output,
-        tags = tags + ["hrepl_test"],
+        tags = tags + ["hrepl_test", "manual"],
         **kwargs
     )


### PR DESCRIPTION
- Mark integration tests "manual"
- Add a missing dependency on `base`.