### PR TITLE
Merge upstream changes and fix warnings.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,8 +18,10 @@ haskell_library(
         "@stackage//:filepath",
         "@stackage//:haskell-src-exts",
         "@stackage//:process",
+        "@stackage//:stm",
         "@stackage//:text",
         "@stackage//:transformers",
+        "@stackage//:typed-process",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,15 @@ load(
 )
 haskell_register_ghc_bindists(
     version = "8.6.5",
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-missing-signatures",
+        "-Wno-type-defaults",
+        "-Wno-trustworthy-safe",
+        "-Wincomplete-uni-patterns",
+        "-Wincomplete-record-updates",
+    ],
 )
 
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
@@ -47,12 +56,14 @@ stack_snapshot(
         "proto-lens",
         "proto-lens-protoc",
         "strict",
+        "stm",
         "temporary",
         "template-haskell",
         "transformers",
         "test-framework",
         "test-framework-hunit",
         "text",
+        "typed-process",
         "unix",
         "vector",
     ],

--- a/hrepl/tests/BUILD.bazel
+++ b/hrepl/tests/BUILD.bazel
@@ -33,7 +33,9 @@ haskell_library(
         "@stackage//:filepath",
         "@stackage//:process",
         "@stackage//:strict",
+        "@stackage//:text",
         "@stackage//:temporary",
+        "@stackage//:typed-process",
     ],
 )
 
@@ -47,6 +49,7 @@ haskell_binary(
         "@stackage//:optparse-applicative",
         "@stackage//:test-framework",
         "@stackage//:test-framework-hunit",
+        "@stackage//:text",
     ],
 )
 
@@ -721,7 +724,8 @@ hrepl_test(
 
 hrepl_test(
     name = "file_name_test",
-    test_args = ["hrepl/tests/Basic.hs"],
+    # The tests run under a subdirectory.
+    test_args = ["../hrepl/tests/Basic.hs"],
     commands = [":main {OUT}"],
     expected_output = "OK",
 )

--- a/hrepl/tests/CLib1.hs
+++ b/hrepl/tests/CLib1.hs
@@ -15,6 +15,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 module CLib1 where
 
-import Foreign.Ptr
-
 foreign import ccall clib1 :: IO Int

--- a/hrepl/tests/CLib2.hs
+++ b/hrepl/tests/CLib2.hs
@@ -15,6 +15,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 module CLib2 where
 
-import Foreign.Ptr
-
 foreign import ccall clib2 :: IO Int

--- a/hrepl/tests/test.bzl
+++ b/hrepl/tests/test.bzl
@@ -75,6 +75,6 @@ def hrepl_test(name="", test_args=[], commands=[], expected_output="", tags=[], 
         test_args = test_args,
         commands = commands,
         expected_output = expected_output,
-        tags = tags + ["hrepl_test", "manual"],
+        tags = tags + ["hrepl_test"],
         **kwargs
     )


### PR DESCRIPTION
- Build with warnings
- Fix some unused `Foreign.Ptr` imports
- Use typed-process to avoid warnings
- Run tests in the "src" subdirectory
- Fix missing dependencies from a unit test
- Use a separate `BazelError` exception type
- Don't mark tests as "manual" (undoing the previous
  commit); it breaks the `test_suite`.