### PR TITLE
Fix a typo in one of the proto tests.

### DIFF
--- a/hrepl/tests/BUILD.bazel
+++ b/hrepl/tests/BUILD.bazel
@@ -520,7 +520,7 @@ hrepl_test(
     test_args = [
         "//hrepl/tests:ProtoLib",
     ],
-    commands = ["apendFile {OUT} (show test)"],
+    commands = ["appendFile {OUT} (show test)"],
     expected_output = "{}",  # The proto text format for an empty message
 )
 


### PR DESCRIPTION
Proto support for hrepl is still TODO (#2), but this test passes on our
internal rules.