### PR TITLE
Add a --interpret-deps flag.

### DIFF
--- a/hrepl/repl_main.hs
+++ b/hrepl/repl_main.hs
@@ -20,7 +20,9 @@ For more information, see ...
 module Main (main)  where
 
 import Data.List (isPrefixOf, partition)
+import qualified Data.Text as Text
 import Bazel (defBazelOpts, BazelOpts(..))
+import Bazel.Name (parsePackageName, PackageName)
 import Repl (runWith, ReplOptions(..))
 import Options.Applicative
 
@@ -33,12 +35,12 @@ data MainOptions = MainOptions
 parseOptions :: Parser MainOptions
 parseOptions =
     MainOptions
-        <$> parseGhciOptions
+        <$> parseReplOptions
 
-parseGhciOptions :: Parser ReplOptions
-parseGhciOptions =
+parseReplOptions :: Parser ReplOptions
+parseReplOptions =
     liftA2 uncurry
-        (ReplOptions <$> bazelOpts <*> packageIds <*> rtsOpts)
+        (ReplOptions <$> bazelOpts <*> packageIds <*> rtsOpts <*> interpretDeps)
         ghcFlagsAndTargets
 
 ghcFlagsAndTargets :: Parser ([String], [String])
@@ -122,6 +124,14 @@ rtsOpts = strOption
               <> metavar "OPTS"
               <> help ("RTS options to be used for running the target. "
                        ++ "Space-separated.")
+
+interpretDeps :: Parser [PackageName]
+interpretDeps = many
+    $ fmap (parsePackageName . Text.pack)
+    $ strOption
+    $ long "interpret-deps"
+    <> metavar "PACKAGE"
+    <> help "Also interpret any dependencies under the given Blaze package."
 
 main :: IO ()
 main = do

--- a/hrepl/tests/BUILD.bazel
+++ b/hrepl/tests/BUILD.bazel
@@ -9,13 +9,7 @@
 
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary", "haskell_library", "ghc_plugin")
 load("@rules_haskell//haskell:protobuf.bzl", "haskell_proto_library")
-load(":test.bzl", "hrepl_test")
-
-# Tags to avoid automatically building certain test targets which intentionally
-# don't build.
-DO_NOT_BUILD = [
-    "manual",
-]
+load(":test.bzl", "DO_NOT_BUILD", "hrepl_test")
 
 haskell_library(
     name = "ReplTestLib",
@@ -471,6 +465,23 @@ hrepl_test(
     test_args = [
         "//hrepl/tests:ReloadOfBroken",
         "//hrepl/tests:ReloadOfBrokenDependency",
+    ],
+    commands = [
+        "appendFile {OUT} test",
+        # "Fix" the file by setting a necessary LANGUAGE pragma.
+        ":set -XOverloadedStrings",
+        ":reload",
+        "appendFile {OUT} (testDep ++ test)",
+    ],
+    expected_output = "OK-depOK",  # Printed only once after reload
+)
+
+hrepl_test(
+    name = "interpret_deps_test",
+    test_args = [
+        "//hrepl/tests/interpret_deps:ReloadOfBrokenDependency",
+        # Interpret :ReloadOfBroken too, so :reload will pick it up.
+        "--interpret-deps=//hrepl/tests/interpret_deps",
     ],
     commands = [
         "appendFile {OUT} test",

--- a/hrepl/tests/interpret_deps/BUILD.bazel
+++ b/hrepl/tests/interpret_deps/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_haskell//haskell:defs.bzl", "haskell_library")
+load("//hrepl/tests:test.bzl", "DO_NOT_BUILD")
+
+haskell_library(
+    name = "ReloadOfBroken",
+    srcs = ["ReloadOfBroken.hs"],
+    # Note: this file intentionally doesn't compile.
+    tags = DO_NOT_BUILD,
+)
+
+haskell_library(
+    name = "ReloadOfBrokenDependency",
+    srcs = ["ReloadOfBrokenDependency.hs"],
+    # Depends on a target that doesn't compile:
+    tags = DO_NOT_BUILD,
+    deps = [":ReloadOfBroken"],
+)

--- a/hrepl/tests/interpret_deps/ReloadOfBroken.hs
+++ b/hrepl/tests/interpret_deps/ReloadOfBroken.hs
@@ -1,0 +1,22 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- | A file which doesn't compile.
+-- In this case, it's because it requires -XOverloadedStrings.
+module ReloadOfBroken where
+
+import Data.String
+
+test :: IsString a => a
+test = "OK"

--- a/hrepl/tests/interpret_deps/ReloadOfBrokenDependency.hs
+++ b/hrepl/tests/interpret_deps/ReloadOfBrokenDependency.hs
@@ -1,0 +1,21 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- | A file depending on a module that doesn't compile.
+module ReloadOfBrokenDependency where
+
+import ReloadOfBroken (test)
+
+testDep :: String
+testDep = test ++ "-dep"

--- a/hrepl/tests/run_tests.sh
+++ b/hrepl/tests/run_tests.sh
@@ -13,6 +13,7 @@ set -x
 bazel build "$@"
 
 OUTPUT="$(mktemp -d)"
+echo $OUTPUT
 trap "bazel --output_base=$OUTPUT/output-base clean --expunge && rm -rf $OUTPUT" EXIT
 
 # Now run each test in sequence, using the same output directory to share the workspace

--- a/hrepl/tests/test.bzl
+++ b/hrepl/tests/test.bzl
@@ -1,5 +1,11 @@
 """A macro for testing hrepl."""
 
+# Tags to avoid automatically building certain test targets which intentionally
+# don't build.
+DO_NOT_BUILD = [
+    "manual",
+]
+
 _hrepl_test_binary = "//hrepl/tests:hrepl_test_binary"
 
 def _quote(s):


### PR DESCRIPTION
This flag lets you specify a subset of dependencies that should all be interpreted.  For example:

```
hrepl TARGET --interpret-deps=//some/project
```
Then every Haskell target living under `//some/project` will be interpreted, as if a separate `-package` flag was passed for it.